### PR TITLE
Résolution du bug des fichiers volumineux

### DIFF
--- a/pages/lecteur/cnaf/index.js
+++ b/pages/lecteur/cnaf/index.js
@@ -24,7 +24,7 @@ export default function Home() {
 
           <Link href="/cnaf/beneficiaire">
             <a className={styles.card}>
-              <h3>Stock bénéficiaires &rarr;</h3>
+              <h3>Bénéficiaires &rarr;</h3>
               <p>Envoyé quotidiennement & mensuellement</p>
             </a>
           </Link>


### PR DESCRIPTION
- Issue #21 
- suppression des .map au profit d'une boucle for
- Le bug survenait à cause d'énormes arrays de HTMLCollection que l'on constituait pour "folders" et "people".
Le stockage de ces arrays dans des variables a été retiré au profit d'une boucle for sur folders.
Les opérations se déroulent désormais toutes à l'intérieur, en incrémentant des accum extérieurs à la boucle for.



- Issue #27 