### PR TITLE
fix(lecteur): Handle large files processing

### DIFF
--- a/lib/readers/BaseFluxReader.js
+++ b/lib/readers/BaseFluxReader.js
@@ -2,7 +2,14 @@ export default class BaseFluxReader {
   constructor(fileContent) {
     const parser = new DOMParser();
     this.dom = parser.parseFromString(fileContent, "application/xml");
-    this.desc = this.dom.getElementsByTagName("IdentificationFlux")[0];
+  }
+
+  get desc() {
+    return this.dom.getElementsByTagName("IdentificationFlux")[0];
+  }
+
+  get applicants() {
+    return new Array(...this.dom.getElementsByTagName("Personne"));
   }
 
   get applicantsCount() {

--- a/lib/readers/FluxBeneficiaireReader.js
+++ b/lib/readers/FluxBeneficiaireReader.js
@@ -6,89 +6,98 @@ export default class FluxBeneficiaireReader extends BaseFluxReader {
     return this.dom.getElementsByTagName("InfosFoyerRSA").length;
   }
 
-  retrieveApplicant(index) {
-    return this.dom.getElementsByTagName("Personne")[index];
+  get applications() {
+    return new Array(...this.dom.getElementsByTagName("InfosFoyerRSA"));
   }
 
-  retrieveApplication(index) {
-    return this.dom.getElementsByTagName("InfosFoyerRSA")[index];
+  get newApplicants() {
+    return this.applicants.filter(applicant => {
+      return applicant.getElementsByTagName("TOPPERSENTDRODEVORSA")[0]?.innerHTML == "1";
+    });
   }
 
   get newApplicantsPersonalData() {
-    const newApplicantsPersonalData = [];
+    return this.newApplicants.map(applicant => {
+      const lastName = applicant.getElementsByTagName("NOM")[0]?.innerHTML;
+      const firstName = applicant.getElementsByTagName("PRENOM")[0]?.innerHTML;
+      const role = APPLICATION_ROLES[applicant.getElementsByTagName("ROLEPERS")[0]?.innerHTML];
+      const rsaApplicationNumber = applicant.parentNode.getElementsByTagName("NUMDEMRSA")[0]
+        ?.innerHTML;
+      const socialSecurityNumber = applicant.parentNode.getElementsByTagName("NIR")[0]?.innerHTML;
 
-    for (let i = 0; i < this.applicantsCount; i++) {
-      const applicant = this.retrieveApplicant(i);
-
-      // TOPPERSDRODEVORSA == "1" <=> New applicant
-      if (applicant.getElementsByTagName("TOPPERSDRODEVORSA")[0]?.innerHTML == "1") {
-        const lastName = applicant.getElementsByTagName("NOM")[0]?.innerHTML;
-        const firstName = applicant.getElementsByTagName("PRENOM")[0]?.innerHTML;
-        const role = APPLICATION_ROLES[applicant.getElementsByTagName("ROLEPERS")[0]?.innerHTML];
-        const rsaApplicationNumber = applicant.parentNode.getElementsByTagName("NUMDEMRSA")[0]
-          ?.innerHTML;
-        const socialSecurityNumber = applicant.parentNode.getElementsByTagName("NIR")[0]?.innerHTML;
-
-        newApplicantsPersonalData.push({
-          rsaApplicationNumber,
-          socialSecurityNumber,
-          lastName,
-          firstName,
-          role,
-        });
-      }
-    }
-
-    return newApplicantsPersonalData;
+      return {
+        rsaApplicationNumber,
+        socialSecurityNumber,
+        lastName,
+        firstName,
+        role,
+      };
+    });
   }
 
-  retrievePartitions() {
-    const [
-      applicationDatesPartition,
-      droitsPartition,
-      devoirsPartition,
-      droitsEtDevoirsPartition,
-      applicantsRolesCount
-    ] = [{}, {}, {}, {}, {}];
-
-    for (let i = 0; i < this.applicationsCount; i++) {
-      const application = this.retrieveApplication(i);
-      const applicationDate = application.getElementsByTagName("DTDEMRSA")[0].innerHTML;
-      applicationDatesPartition[applicationDate] =
-        (applicationDatesPartition[applicationDate] || 0) + 1;
-      this.updatePartition(droitsPartition, application.getElementsByTagName("ETATDOSRSA"));
-      this.updatePartition(devoirsPartition, application.getElementsByTagName("TOPPERSDRODEVORSA"));
-
-      const applicants = application.getElementsByTagName("Personne");
-      [...applicants].forEach(applicant => {
-        this.updatePartition(
-          applicantsRolesCount,
-          applicant.getElementsByTagName("ROLEPERS")
-        );
-        if (applicant.getElementsByTagName("ETATDOSRSA")[0]?.innerHTML == "2") {
-          this.updatePartition(
-            droitsEtDevoirsPartition,
-            applicant.getElementsByTagName("TOPPERSDRODEVORSA")[0].innerHTML
-          );
-        }
-      });
-    }
-
+  static get initialPartitions() {
     return {
-      applicationDatesPartition,
-      droitsPartition,
-      devoirsPartition,
-      droitsEtDevoirsPartition,
-      applicantsRolesCount
+      applicationDatesPartition: {},
+      droitsPartition: {},
+      devoirsPartition: {},
+      droitsEtDevoirsPartition: {},
+      applicantsRolesPartition: {},
+      applicantsCount: 0,
+      applicationsCount: 0,
     };
   }
 
-  updatePartition(accum, value) {
-    if (value[0]) {
-      accum[value[0].innerHTML] = (accum[value[0].innerHTML] || 0) + 1;
+  retrievePartitions() {
+    return this.updatePartitions(FluxBeneficiaireReader.initialPartitions);
+  }
 
-      accum["Total"] = (accum["Total"] || 0) + 1;
+  updatePartitions(partitionsToUpdate) {
+    return this.applications.reduce((partitions, application) => {
+      partitions.applicationsCount += 1;
+      this.updatePartition(
+        partitions.applicationDatesPartition,
+        application.getElementsByTagName("DTDEMRSA"),
+        false
+      );
+      this.updatePartition(
+        partitions.droitsPartition,
+        application.getElementsByTagName("ETATDOSRSA")
+      );
+      this.updatePartition(
+        partitions.devoirsPartition,
+        application.getElementsByTagName("TOPPERSDRODEVORSA")
+      );
+
+      const applicants = new Array(...application.getElementsByTagName("Personne"));
+
+      partitions.applicantsCount += applicants.length;
+
+      applicants.forEach(applicant => {
+        this.updatePartition(
+          partitions.applicantsRolesPartition,
+          applicant.getElementsByTagName("ROLEPERS")
+        );
+        if (application.getElementsByTagName("ETATDOSRSA")[0]?.innerHTML == "2") {
+          this.updatePartition(
+            partitions.droitsEtDevoirsPartition,
+            applicant.getElementsByTagName("TOPPERSDRODEVORSA")
+          );
+        }
+      });
+      return partitions;
+    }, partitionsToUpdate);
+  }
+
+  updatePartition(partition, value, withTotal = true) {
+    if (!value[0]) {
+      return;
     }
-    return accum;
+
+    partition[value[0].innerHTML] = (partition[value[0].innerHTML] || 0) + 1;
+
+    if (withTotal) {
+      partition["Total"] = (partition["Total"] || 0) + 1;
+    }
+    return partition;
   }
 }

--- a/lib/readers/FluxInstructionReader.js
+++ b/lib/readers/FluxInstructionReader.js
@@ -6,10 +6,6 @@ export default class FluxInstructionReader extends BaseFluxReader {
     return new Array(...this.dom.getElementsByTagName("InfoDemandeRSA"));
   }
 
-  get applicants() {
-    return new Array(...this.dom.getElementsByTagName("Personne"));
-  }
-
   get applicationsCount() {
     return this.dom.getElementsByTagName("InfoDemandeRSA").length;
   }

--- a/lib/reducerFactory.js
+++ b/lib/reducerFactory.js
@@ -17,6 +17,10 @@ function reducerFactory(logName) {
         }
         push(["trackEvent", logName, JSON.stringify({ ...logData, seed: undefined })]);
         return [action.item, ...state];
+      case "update":
+        const elIndex = state.findIndex(el => el.seed === action.item.seed);
+        state[elIndex] = { ...state[elIndex], ...action.item };
+        return state;
       case "replace":
         return action.items;
       case "reset":


### PR DESCRIPTION
## Main Objectives

In this PR I add the ability to read large files (> 500 Mo) from our app to let departments compute stats from their monthly flux.
To do so I read large file by chunks and not in their entirety. This is possible thanks to the [readAsArrayBuffer](https://developer.mozilla.org/fr/docs/Web/API/FileReader/readAsArrayBuffer) method that lets you read files by [blobs](https://developer.mozilla.org/fr/docs/Web/API/Blob). 
All the file blobs we read are of the same size (512 * 1024 bytes).  However we don't keep all the text that contains those chunks, we only extract the info from one application (`<InfosFoyerRsa>...</InfosFoyerRsa>`) and retrieve data from it. 
The next chunk will start from where this processed application ended. 
This is described in this drawing: 

![image](https://user-images.githubusercontent.com/7602809/116426077-172c8180-a843-11eb-9705-d50afff5c5cb.png)

Also due to the async nature of the JS `FileReader` API, I put this logic inside a `Promise` to process one chunk after the other synchronously. 

**Benchmark**: 

On Google Chrome, I was able to process a real flux of 783.4 Mo in 1181 seconds (~20 min).
This could be improved if needed by processing several applications in one chunk.

## Side note

I took this opportunity to correct the miscalculations we were having described in #45 that I introduced by fetching the `ETATDORSA` value on the applicant level instead of the application level [here](https://github.com/betagouv/analyse-flux-insertion/blob/1977e9a4e1f09ec45cd6fd01e9b115235d6e1608/lib/readers/FluxBeneficiaireReader.js#L68).