### PR TITLE
fix(deps): Do not use next image api

### DIFF
--- a/components/NewApplicantsRules.js
+++ b/components/NewApplicantsRules.js
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import styles from "./NewApplicantsRules.module.css";
 
 export default function NewApplicantsRules() {
@@ -40,11 +39,10 @@ export default function NewApplicantsRules() {
           </p>
           <p>
             <div className={styles.image_container}>
-              <Image
+              <img
                 src="/new_applicants_rules.png"
                 alt="new_applicants_rules"
-                width={3146}
-                height={1398}
+                className={styles.rules_image}
               />
             </div>
           </p>

--- a/components/NewApplicantsRules.module.css
+++ b/components/NewApplicantsRules.module.css
@@ -11,3 +11,9 @@
 .image_container {
   text-align: center;
 }
+
+.rules_image {
+  width: 100%;
+  max-width: 1080px;
+  height: auto;
+}


### PR DESCRIPTION
Next image API requires a third party loader to export with the Image API (more infos [here](https://nextjs.org/docs/messages/export-image-api)).
Since we are not taking advantage of it I replaced it with a simple `<img>` tag.