### PR TITLE
 enhancement/add_wrong_organization_error_message 

### DIFF
--- a/pages/experimentations/ardennes/index.js
+++ b/pages/experimentations/ardennes/index.js
@@ -122,7 +122,7 @@ export default function Ardennes() {
       alert("L'adresse mail n'est pas valide");
     } else if (result.errors && result.errors.first_name && result.errors.first_name[0].error === "déjà utilisé") {
       alert("La création du compte a échoué. L'utilisateur semble exister mais n'a pu être récupéré.");
-    } else if (result.errors && result.errors[0] && result.errors[0].base && result.errors[0].base === "forbidden") {
+    } else if (result.errors && result.errors[0] && result.errors[0].base === "forbidden") {
       alert("Votre compte agent RDV-Solidarités ne vous permet pas d'effectuer cette action.");
     } else if (result.errors && result.errors[0]) {
       alert(result.errors[0]);

--- a/pages/experimentations/ardennes/index.js
+++ b/pages/experimentations/ardennes/index.js
@@ -109,23 +109,22 @@ export default function Ardennes() {
     const result = await appFetch(userUrl, token, "POST", JSON.stringify(user));
 
     let newUsersData = [...usersData];
-    const mail_error = result.errors.email?.shift()
     if (result.user) {
       newUsersData[userIndex]["ID RDV"] = result.user.id;
       setUsersData(newUsersData);
       generateInvitationUrl(result.user.id, userIndex);
-    } else if (mail_error.error === "taken") {
-      newUsersData[userIndex]["ID RDV"] = mail_error.id;
+    } else if (result?.errors.email && result.errors.email[0] === "taken") {
+      newUsersData[userIndex]["ID RDV"] = result.errors.email[0].id;
       setUsersData(newUsersData);
-      checkUserInvitationStatus(mail_error.id, userIndex);
+      checkUserInvitationStatus(result.errors.email[0].id, userIndex);
       alert("Un compte associé à cet email existe déjà");
-    } else if (mail_error.error === "invalid") {
+    } else if (result.errors?.email && result.errors.email[0].error === "invalid") {
       alert("L'adresse mail n'est pas valide");
-    } else if (result.errors.first_name?.shift().error === "déjà utilisé") {
+    } else if (result.errors?.first_name && result.errors.first_name[0].error === "déjà utilisé") {
       alert("La création du compte a échoué. L'utilisateur semble exister mais n'a pu être récupéré.");
-    } else if (result.errors?.shift().base === "forbidden") {
+    } else if (result.errors[0] && result.errors[0].base && result.errors[0].base === "forbidden") {
       alert("Votre compte agent RDV-Solidarités ne vous permet pas d'effectuer cette action.");
-    } else if (result.errors[0]) {
+    } else if (result?.errors[0]) {
       alert(result.errors[0]);
     }
   }

--- a/pages/experimentations/ardennes/index.js
+++ b/pages/experimentations/ardennes/index.js
@@ -67,9 +67,13 @@ export default function Ardennes() {
     }
   }
 
-  async function checkUserInvitationStatus(userId, userIndex) {
+  async function getUser(userId, token) {
     const getUserUrl = userUrl + `/${userId}`;
-    const result = await appFetch(getUserUrl, token);
+    return await appFetch(getUserUrl, token);
+  }
+
+  async function checkUserInvitationStatus(userId, userIndex) {
+    const result = await getUser(userId, token);
 
     let newUsersData = [...usersData];
     if (result.user.invitation_created_at) {
@@ -105,26 +109,23 @@ export default function Ardennes() {
     const result = await appFetch(userUrl, token, "POST", JSON.stringify(user));
 
     let newUsersData = [...usersData];
+    const mail_error = result.errors.email?.shift()
     if (result.user) {
       newUsersData[userIndex]["ID RDV"] = result.user.id;
       setUsersData(newUsersData);
       generateInvitationUrl(result.user.id, userIndex);
-    } else if (result.errors && result.errors.email && result.errors.email[0].error === "taken") {
-      newUsersData[userIndex]["ID RDV"] = result.errors.email[0].id;
+    } else if (mail_error.error === "taken") {
+      newUsersData[userIndex]["ID RDV"] = mail_error.id;
       setUsersData(newUsersData);
-      checkUserInvitationStatus(result.errors.email[0].id, userIndex);
+      checkUserInvitationStatus(mail_error.id, userIndex);
       alert("Un compte associé à cet email existe déjà");
-    } else if (
-      result.errors &&
-      result.errors.first_name &&
-      result.errors.first_name[0].error === "déjà utilisé"
-    ) {
-      alert(
-        "La création de ce compte a échoué. L'utilisateur semble déjà exister mais n'a pas pu être récupéré."
-      );
-    } else if (result.errors.email && result.errors.email[0].error === "invalid") {
+    } else if (mail_error.error === "invalid") {
       alert("L'adresse mail n'est pas valide");
-    } else if (result.errors && result.errors[0]) {
+    } else if (result.errors.first_name?.shift().error === "déjà utilisé") {
+      alert("La création du compte a échoué. L'utilisateur semble exister mais n'a pu être récupéré.");
+    } else if (result.errors?.shift().base === "forbidden") {
+      alert("Votre compte agent RDV-Solidarités ne vous permet pas d'effectuer cette action.");
+    } else if (result.errors[0]) {
       alert(result.errors[0]);
     }
   }

--- a/pages/experimentations/ardennes/index.js
+++ b/pages/experimentations/ardennes/index.js
@@ -113,18 +113,18 @@ export default function Ardennes() {
       newUsersData[userIndex]["ID RDV"] = result.user.id;
       setUsersData(newUsersData);
       generateInvitationUrl(result.user.id, userIndex);
-    } else if (result?.errors.email && result.errors.email[0] === "taken") {
+    } else if (result.errors && result.errors.email && result.errors.email[0].error === "taken") {
       newUsersData[userIndex]["ID RDV"] = result.errors.email[0].id;
       setUsersData(newUsersData);
       checkUserInvitationStatus(result.errors.email[0].id, userIndex);
       alert("Un compte associé à cet email existe déjà");
-    } else if (result.errors?.email && result.errors.email[0].error === "invalid") {
+    } else if (result.errors && result.errors.email && result.errors.email[0].error === "invalid") {
       alert("L'adresse mail n'est pas valide");
-    } else if (result.errors?.first_name && result.errors.first_name[0].error === "déjà utilisé") {
+    } else if (result.errors && result.errors.first_name && result.errors.first_name[0].error === "déjà utilisé") {
       alert("La création du compte a échoué. L'utilisateur semble exister mais n'a pu être récupéré.");
-    } else if (result.errors[0] && result.errors[0].base && result.errors[0].base === "forbidden") {
+    } else if (result.errors && result.errors[0] && result.errors[0].base && result.errors[0].base === "forbidden") {
       alert("Votre compte agent RDV-Solidarités ne vous permet pas d'effectuer cette action.");
-    } else if (result?.errors[0]) {
+    } else if (result.errors && result.errors[0]) {
       alert(result.errors[0]);
     }
   }


### PR DESCRIPTION
Dans cette PR, j'ai 
- ajouté la prise en compte spécifique du cas où l'agent tentant de créer les usagers n'appartient pas à l'organisation Ardennes (bug rencontré par Claire), 
- séparé l'appel de `getUser()`. 
- simplifié (ou plutôt, péniblement essayé de simplifier) l'écriture des différents if pour la prise en charge des erreurs, avec des `?` puis finalement des `shift()`

Pour la prise en charge de l'erreur : 
- J'ai envisagé dans un premier temps de le faire au moment du login, mais les infos sur l'agent renvoyées dans le body de la response comprennent le service, mais pas l'organisation (et les infos renvoyés sont générées automatiquement par devise_token_auth, une customization aurait pris trop de temps pour l'utilité). 
- J'ai ensuite pensé lancer un get de user au moment du login, mais ce get n'est possible que sur les users (usagers) et pas sur les agents. C'est à ce moment-là que j'ai séparé la méthode `getUser()` de la méthode `checkUserInvitationStatus()` ; le faire n'a plus d'utilité directe au final, mais cela pourra reservir par la suite, j'ai donc décider de garder ce changement. 
- J'ai finalement opté pour la prise en charge de cette erreur au moment de la tentative de création de compte.
