### PR TITLE
feat(ops): Make staging to prod transitions easy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ yarn deploy
 
 The added changes will then be visible on [https://betagouv.github.io/analyse-flux-insertion/](https://betagouv.github.io/analyse-flux-insertion/).
 
+### Apply changes to production pages
+
+Some pages are targetting demo environments of [`RDV-Solidarités`](https://github.com/betagouv/rdv-solidarites.fr). Since this application does not have a staging environment, we have pages targetting the demo env and pages targetting the prod env.
+
+Once the changes are tested on the demo env, you can apply them to the pages targetting the production environments by running:
+
+```bash
+npm run apply-to-production-pages
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/apply_changes_to_production_pages.sh
+++ b/apply_changes_to_production_pages.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+# This script applies, commits and pushes the changes made on the pages
+# targetting demo app of RDV-Solidarités to the pages targetting the prod app
+# ---------------------------------------------------------------
+
+# Make sure we fail and exit if an error is encountered
+set -e
+
+# Prints text with colour based on the message's importance level
+print_text () {
+  if [ "$2" == "info" ]
+  then
+      COLOR="96m"
+  elif [ "$2" == "success" ]
+  then
+      COLOR="92m"
+  elif [ "$2" == "warning" ]
+  then
+      COLOR="93m"
+  elif [ "$2" == "danger" ]
+  then
+      COLOR="91m"
+  else
+      COLOR="0m"
+  fi
+
+  STARTCOLOR="\e[$COLOR"
+  ENDCOLOR="\e[0m"
+
+  printf "$STARTCOLOR%b$ENDCOLOR$ENDCHARACTER" "$1";
+}
+
+# Exits the script after printing a warning message
+exit_with_message () {
+  print_text "$1\n" "warning"
+  exit 1
+}
+
+print_text "\nMerge and deploy\n" "info"
+print_text "------------------------\n\n"
+
+# Gets the current branch by looking for `*` character
+# - `s/` is for substitution
+# - `/p` prints the result
+current_branch=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
+
+# Make sure that we are on staging branch
+print_text "Branch check: "
+if [ $current_branch != "main" ]
+then
+    print_text "Failed\n" "danger"
+    exit_with_message "To be able to deploy you need to be on the 'main' branch. Aborting."
+else
+    print_text "OK\n" "success"
+fi
+
+print_text "\n"
+
+# Get the git status
+# - `porcelain` flag returns the output in an easy to parse format for scripts
+st=$(git status --porcelain 2> /dev/null)
+
+# # Make sure that the status is clean
+print_text "Git status check: "
+if [[ "$st" != "" ]];
+then
+    print_text "Failed\n" "danger"
+    exit_with_message "To be able to deploy, 'git status' should be clean. Aborting."
+else
+    print_text "OK\n" "success"
+fi
+
+print_text "\n"
+
+git pull -r origin main
+print_text "Pulling latest 'main' changes: "
+print_text "OK\n" "success"
+
+print_text "\n"
+
+print_text "Copying the file: "
+
+cp pages/experimentations/ardennes-demo/index.js pages/experimentations/ardennes/index.js
+
+print_text "Copying the file: "
+print_text "OK\n" "success"
+
+git add pages/experimentations/ardennes/index.js
+git commit -m "chore(experimentations): Apply changes to production pages"
+git push origin main
+
+print_text "Pushing to 'master': "
+print_text "OK\n" "success"
+
+print_text "\n"
+
+

--- a/apply_changes_to_production_pages.sh
+++ b/apply_changes_to_production_pages.sh
@@ -37,7 +37,7 @@ exit_with_message () {
   exit 1
 }
 
-print_text "\nMerge and deploy\n" "info"
+print_text "\nPush changes\n" "info"
 print_text "------------------------\n\n"
 
 # Gets the current branch by looking for `*` character
@@ -45,7 +45,7 @@ print_text "------------------------\n\n"
 # - `/p` prints the result
 current_branch=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
 
-# Make sure that we are on staging branch
+# Make sure that we are on main branch
 print_text "Branch check: "
 if [ $current_branch != "main" ]
 then
@@ -61,7 +61,7 @@ print_text "\n"
 # - `porcelain` flag returns the output in an easy to parse format for scripts
 st=$(git status --porcelain 2> /dev/null)
 
-# # Make sure that the status is clean
+# Make sure that the status is clean
 print_text "Git status check: "
 if [[ "$st" != "" ]];
 then

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "deploy": "npm run build && npm run deploy:github",
     "deploy:github": "touch out/.nojekyll && gh-pages -d out --dotfiles",
     "dev": "next dev",
-    "start": "next start"
+    "start": "next start",
+    "apply-to-production-pages": "./apply_to_production_pages.sh && npm run deploy"
   },
   "dependencies": {
     "@nivo/calendar": "^0.67.0",

--- a/pages/experimentations/ardennes-demo/index.js
+++ b/pages/experimentations/ardennes-demo/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState, useReducer } from "react";
+import { useRouter } from "next/router";
 import * as XLSX from "xlsx";
 
 import Layout from "../../../components/layout";
@@ -12,12 +13,20 @@ import { initReducer, reducerFactory } from "../../../lib/reducerFactory";
 import { getDateTimeString, getFrenchFormatDateString, stringToDate } from "../../../lib/dates";
 
 const reducer = reducerFactory("Expérimentation Ardennes - CNAF - Bénéficiaire");
-const devMode = process.env.NODE_ENV == "development";
-const orgaID = process.env.NEXT_PUBLIC_ORGANISATION_ID_DEMO;
-const RDV_SOLIDARITES_URL = process.env.NEXT_PUBLIC_RDV_SOLIDARITES_DEMO_URL;
-const userUrl = RDV_SOLIDARITES_URL + "/api/v1/users";
 
 export default function Ardennes() {
+  const router = useRouter();
+  const isDemo = router.pathname.includes("demo");
+  const devMode = process.env.NODE_ENV == "development";
+  const orgaID = isDemo
+    ? process.env.NEXT_PUBLIC_ORGANISATION_ID_DEMO
+    : process.env.NEXT_PUBLIC_ORGANISATION_ID_PROD;
+
+  const RDV_SOLIDARITES_URL = isDemo
+    ? process.env.NEXT_PUBLIC_RDV_SOLIDARITES_DEMO_URL
+    : process.env.NEXT_PUBLIC_RDV_SOLIDARITES_PROD_URL;
+  const userUrl = RDV_SOLIDARITES_URL + "/api/v1/users";
+
   const [devFile, setDevFile] = useState(null);
   const [runs, dispatchRuns] = useReducer(reducer, [], initReducer);
   const [usersData, setUsersData] = useState(null);
@@ -189,7 +198,7 @@ export default function Ardennes() {
           },
         });
         resolve();
-      };;
+      };
       reader.readAsArrayBuffer(file);
     });
   };

--- a/pages/experimentations/ardennes/index.js
+++ b/pages/experimentations/ardennes/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState, useReducer } from "react";
+import { useRouter } from "next/router";
 import * as XLSX from "xlsx";
 
 import Layout from "../../../components/layout";
@@ -12,12 +13,20 @@ import { initReducer, reducerFactory } from "../../../lib/reducerFactory";
 import { getDateTimeString, getFrenchFormatDateString, stringToDate } from "../../../lib/dates";
 
 const reducer = reducerFactory("Expérimentation Ardennes - CNAF - Bénéficiaire");
-const devMode = process.env.NODE_ENV == "development";
-const orgaID = process.env.NEXT_PUBLIC_ORGANISATION_ID_PROD;
-const RDV_SOLIDARITES_URL = process.env.NEXT_PUBLIC_RDV_SOLIDARITES_PROD_URL;
-const userUrl = RDV_SOLIDARITES_URL + "/api/v1/users";
 
 export default function Ardennes() {
+  const router = useRouter();
+  const isDemo = router.pathname.includes("demo");
+  const devMode = process.env.NODE_ENV == "development";
+  const orgaID = isDemo
+    ? process.env.NEXT_PUBLIC_ORGANISATION_ID_DEMO
+    : process.env.NEXT_PUBLIC_ORGANISATION_ID_PROD;
+
+  const RDV_SOLIDARITES_URL = isDemo
+    ? process.env.NEXT_PUBLIC_RDV_SOLIDARITES_DEMO_URL
+    : process.env.NEXT_PUBLIC_RDV_SOLIDARITES_PROD_URL;
+  const userUrl = RDV_SOLIDARITES_URL + "/api/v1/users";
+
   const [devFile, setDevFile] = useState(null);
   const [runs, dispatchRuns] = useReducer(reducer, [], initReducer);
   const [usersData, setUsersData] = useState(null);
@@ -242,8 +251,8 @@ export default function Ardennes() {
                       </thead>
                       <tbody>
                         {/* reverse est utilisé pour que les utilisateurs les plus récents apparaissent en haut */}
-                        {[...usersData].reverse().map((user, index) =>
-                          {user["DATE"] !== "" && (
+                        {[...usersData].reverse().map((user, index) => {
+                          user["DATE"] !== "" && (
                             <tr key={index}>
                               <td className={styles.center}>{user["DATE"]}</td>
                               <td className={styles.center}>{user["NOM"]}</td>
@@ -275,8 +284,8 @@ export default function Ardennes() {
                               )}
                               {user["ID RDV"] === "" && <td className={styles.center}></td>}
                             </tr>
-                          )}
-                        )}
+                          );
+                        })}
                       </tbody>
                     </table>
 


### PR DESCRIPTION
This PR is linked to #63. 
In this PR: 

- I changed the Ardennes demo and prod pages so that they are exactly the same. The RDV-Solidarités URL will be set depending of the page we are in.
- I wrote a [bash script](https://github.com/betagouv/analyse-flux-insertion/blob/afd58946db8196e63a31d938ad0dfb346a76f6bc/apply_changes_to_production_pages.sh) that copies the content of the demo page to the prod page, and then commits it and pushes it. So now, whenever we are satisfied by the changes we previously pushed to demo, we can apply them to the prod pages by running `npm run apply-to-production-pages`.