### PR TITLE
Correction de bug pour Ardennes

### DIFF
--- a/pages/experimentations/ardennes-demo/index.js
+++ b/pages/experimentations/ardennes-demo/index.js
@@ -263,9 +263,11 @@ export default function Ardennes() {
 
                                 {user["ID RDV"] === "" && (
                                   <td className={styles.center}>
-                                    <button onClick={() => createUser(user, index)}>
+                                    <button
+                                      onClick={() => createUser(user, usersData.length - index - 1)}
+                                    >
                                       Créer un compte
-                                  </button>
+                                    </button>
                                   </td>
                                 )}
                                 {user["ID RDV"] !== "" && (


### PR DESCRIPTION
Après l'inversion de l'affichage du tableau en front, un bug était apparu lié à la transmission de l'index dans la méthode createUser