### PR TITLE
fix(ops): Remove warning when executing shell script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "deploy:github": "touch out/.nojekyll && gh-pages -d out --dotfiles",
     "dev": "next dev",
     "start": "next start",
-    "apply-to-production-pages": "./apply_changes_to_production_pages.sh && npm run deploy"
+    "apply-to-production-pages": "bash ./apply_changes_to_production_pages.sh && npm run deploy"
   },
   "dependencies": {
     "@nivo/calendar": "^0.67.0",


### PR DESCRIPTION
Some warning can be displayed when applying to production pages. According to this [SO reply](https://stackoverflow.com/questions/3411048/unexpected-operator-in-shell-programming/3411061), prefixing the execution with `bash` should fix it.