### PR TITLE
Feat/Ardennes => Eviter d'enregistrer des NIR dans RDV-Solidarités

### DIFF
--- a/pages/experimentations/ardennes-demo/index.js
+++ b/pages/experimentations/ardennes-demo/index.js
@@ -105,7 +105,7 @@ export default function Ardennes() {
 
   async function createUser(userData, userIndex) {
     const address = userData["ADRESSE"] + " - " + userData["CODE POSTAL"] + " " + userData["VILLE"];
-    if ([13, 15].includes(userData["N°CAF"].trim().length)) { userData["N°CAF"] = "" }
+    if ([13, 15].includes(userData["N°CAF"].trim().length)) userData["N°CAF"] = ""
 
     let user = {
       first_name: userData["PRENOM"],

--- a/pages/experimentations/ardennes-demo/index.js
+++ b/pages/experimentations/ardennes-demo/index.js
@@ -105,6 +105,9 @@ export default function Ardennes() {
 
   async function createUser(userData, userIndex) {
     const address = userData["ADRESSE"] + " - " + userData["CODE POSTAL"] + " " + userData["VILLE"];
+    userData["N°CAF"].trim().length == 13 || userData["N°CAF"].trim().length == 15
+      ? userData["N°CAF"] = ""
+      : userData["N°CAF"] = userData["N°CAF"];
 
     let user = {
       first_name: userData["PRENOM"],

--- a/pages/experimentations/ardennes-demo/index.js
+++ b/pages/experimentations/ardennes-demo/index.js
@@ -105,9 +105,7 @@ export default function Ardennes() {
 
   async function createUser(userData, userIndex) {
     const address = userData["ADRESSE"] + " - " + userData["CODE POSTAL"] + " " + userData["VILLE"];
-    userData["N°CAF"].trim().length == 13 || userData["N°CAF"].trim().length == 15
-      ? userData["N°CAF"] = ""
-      : userData["N°CAF"] = userData["N°CAF"];
+    if ([13, 15].includes(userData["N°CAF"].trim().length)) { userData["N°CAF"] = "" }
 
     let user = {
       first_name: userData["PRENOM"],


### PR DESCRIPTION
Cette PR introduit un check au moment de la création de l'utilisateur sur RDV-Solidarités pour éviter d'y stocker des NIR.