### PR TITLE
refactor(identifieur): Change id definition

### DIFF
--- a/models/Applicant.js
+++ b/models/Applicant.js
@@ -71,12 +71,7 @@ export default class Applicant {
 
   // string used to identify applicants
   get id() {
-    return [
-      this.rsaApplicationNumber,
-      this.lastName.split(" ").join("-"),
-      this.firstName.split(" ").join("-"),
-      this.role,
-    ].join("-");
+    return [this.rsaApplicationNumber, this.role].join("-");
   }
 
   personalData() {
@@ -101,15 +96,8 @@ export default class Applicant {
     return this.topEntrant === "1";
   }
 
-  eligibleAsNew() {
-    return (
-      this.application.eligibleAsNew() &&
-      (this.withDroitsEtDevoirs() || this.eligibleAsNewInFoyer())
-    );
-  }
-
-  eligibleAsNewInFoyer() {
-    return this.inFoyerWithDroitsEtDevoirs() && ["ENF", "AUT"].includes(this.role);
+  withRights() {
+    return this.application.withRights() && this.withDroitsEtDevoirs();
   }
 
   inFoyerWithDroitsEtDevoirs() {

--- a/models/Application.js
+++ b/models/Application.js
@@ -49,7 +49,7 @@ export default class Application {
     return this.dom.getElementsByTagName("TOPFOYDRODEVORSA")[0]?.innerHTML;
   }
 
-  eligibleAsNew() {
+  withRights() {
     return (
       this.withDroitsOuvertsEtVersables() ||
       (this.withDroitsOuvertsSuspendu() &&

--- a/models/BaseFlux.js
+++ b/models/BaseFlux.js
@@ -16,13 +16,6 @@ export default class BaseFlux {
     });
   }
 
-  // { 123123-Dupont-Jean-DEM: { firstName: ... }, ... }
-  get applicantsObject() {
-    return this.applicants.reduce((applicantsObject, applicant) => {
-      applicantsObject[applicant.id] = applicant;
-      return applicantsObject;
-    }, {});
-  }
   get applicantsCount() {
     return this.applicants.length;
   }

--- a/models/FluxBeneficiaire.js
+++ b/models/FluxBeneficiaire.js
@@ -15,12 +15,6 @@ export default class FluxBeneficiaire extends BaseFlux {
     });
   }
 
-  get applicantsEligibleAsNew() {
-    return this.applicants.filter(applicant => {
-      return applicant.eligibleAsNew();
-    });
-  }
-
   get applicantsWithDroitsOuvertsEtVersables() {
     return this.applicants.filter(applicant => {
       return applicant.application.withDroitsOuvertsEtVersables();
@@ -29,7 +23,7 @@ export default class FluxBeneficiaire extends BaseFlux {
 
   get applicantsWithRights() {
     return this.applicants.filter(applicant => {
-      return applicant.application.eligibleAsNew() && applicant.withDroitsEtDevoirs();
+      return applicant.withRights();
     });
   }
 

--- a/pages/identification-beneficiaires/flux-mensuels/index.js
+++ b/pages/identification-beneficiaires/flux-mensuels/index.js
@@ -315,7 +315,7 @@ export default function identificationBeneficiaire() {
         <h1>Identifiez les nouveaux demandeurs à l'aide des flux CNAF</h1>
         <ol>
           <li style={step === "previousMonth" ? { fontWeight: "bold" } : {}}>
-            Uploadez le flux mensuel du mois précédent le fichier que vous voulez analyser (
+            Uploadez le flux mensuel du mois précédant le fichier que vous voulez analyser (
             <strong>M - 1</strong>)
           </li>
           <br />

--- a/pages/identification-beneficiaires/flux-quotidiens/index.js
+++ b/pages/identification-beneficiaires/flux-quotidiens/index.js
@@ -342,7 +342,7 @@ export default function identificationBeneficiaire() {
 
         <ol>
           <li style={step === "previousMonth" ? { fontWeight: "bold" } : {}}>
-            Uploadez le flux mensuel du mois précédent le fichier que vous voulez analyser (
+            Uploadez le flux mensuel du mois précédant le fichier que vous voulez analyser (
             <strong>M - 1</strong>)
           </li>
           <br />


### PR DESCRIPTION
Dans cette PR je n'utilise plus les noms dans les "ids" que je génère pour les demandeurs, je ne m'appuie plus que sur le numéro de demande et le rôle (comme les enfants ne sont pas soumis à droits et devoirs, ce duo d'informations devrait être unique).
J'ai également supprimé les méthodes qui n'étaient plus utilisées.