### PR TITLE
Bug dates de naissance

### DIFF
--- a/pages/experimentations/ardennes-demo/index.js
+++ b/pages/experimentations/ardennes-demo/index.js
@@ -138,7 +138,7 @@ export default function Ardennes() {
       first_name: userData["PRENOM"],
       last_name: userData["NOM"],
       phone_number: userData["TELEPHONE"].replace(/\s+/g, ""),
-      birth_date: stringToDate(userData["DATE DE NAISSANCE"]),
+      birth_date: applicationDateToString(stringToDate(userData["DATE DE NAISSANCE"])),
       address: address,
       caisse_affiliation: "caf",
       affiliation_number: userData["N°CAF"],


### PR DESCRIPTION
Résous l'issue #91 (décalage de un jour sur les dates de naissance au moment de créer l'utilisateur sur le serveur de RDV-Solidarités