### PR TITLE
refactor(Ardennes): fill with invitation url for users with mail

### DIFF
--- a/pages/experimentations/ardennes-demo/index.js
+++ b/pages/experimentations/ardennes-demo/index.js
@@ -75,9 +75,10 @@ export default function Ardennes() {
     const result = await appFetch(invitationUrl, token);
 
     let newUsersData = [...usersData];
-    if (result.invitation_url) {
+    let userEmail = newUsersData[userIndex]["MAIL"]
+    if (userEmail && userEmail.length > 0) {
       newUsersData[userIndex]["Lien d'invitation"] = result.invitation_url;
-    } else if (result.invitation_token) {
+    } else {
       newUsersData[userIndex]["Code d'invitation"] = result.invitation_token;
     }
     newUsersData[userIndex]["Date d'invitation"] = getFrenchFormatDateString(new Date());

--- a/pages/experimentations/ardennes/index.js
+++ b/pages/experimentations/ardennes/index.js
@@ -75,9 +75,10 @@ export default function Ardennes() {
     const result = await appFetch(invitationUrl, token);
 
     let newUsersData = [...usersData];
-    if (result.invitation_url) {
+    let userEmail = newUsersData[userIndex]["MAIL"]
+    if (userEmail && userEmail.length > 0) {
       newUsersData[userIndex]["Lien d'invitation"] = result.invitation_url;
-    } else if (result.invitation_token) {
+    } else {
       newUsersData[userIndex]["Code d'invitation"] = result.invitation_token;
     }
     newUsersData[userIndex]["Date d'invitation"] = getFrenchFormatDateString(new Date());


### PR DESCRIPTION
Ce n'est pas au serveur de nous dire si l'on doit utiliser un lien d'invitation ou le token mais au client en fonction de s'il y a une adresse mail ou non.