### PR TITLE
Hotfix/Réduire les appels à l'API de RDV-Solidarités

### DIFF
--- a/pages/experimentations/ardennes-demo/index.js
+++ b/pages/experimentations/ardennes-demo/index.js
@@ -53,7 +53,7 @@ export default function Ardennes() {
   useEffect(() => {
     if (usersData && userStatusChecked === false) {
       usersData.forEach((user, userIndex) => {
-        if (user["ID RDV"] != "") {
+        if (user["ID RDV"] && user["ID RDV"].length > 0 && !user["Date d'inscription"]) {
           checkUserInvitationStatus(user["ID RDV"], userIndex);
         }
       });


### PR DESCRIPTION
Pour éviter les appels inutiles à l'API RDV-Solidarités, les utilisateurs ayant déjà validé leur compte (= aux utilistaeurs ayant la colonne "Date d'inscription" déjà remplie) ne seront plus vérifiés au chargement du fichier.